### PR TITLE
Hide Cursor in page

### DIFF
--- a/src/themes/DVDScreensaver/index.js
+++ b/src/themes/DVDScreensaver/index.js
@@ -99,6 +99,7 @@ function DVDScreensaver({ className }) {
 export default styled(DVDScreensaver)`
   background-color: #000;
   height: 100%;
+  cursor: none;
   overflow: hidden;
   .logo {
     overflow: hidden;

--- a/src/themes/MacOS/index.js
+++ b/src/themes/MacOS/index.js
@@ -74,6 +74,7 @@ export default styled(MacOS)`
   @import url('https://fonts.googleapis.com/css?family=Roboto:300');
   height: 100%;
   background: #000;
+  cursor: none;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/themes/Win10Blue/index.js
+++ b/src/themes/Win10Blue/index.js
@@ -25,6 +25,7 @@ const Win10Blue = ({ className }) => {
 export default styled(Win10Blue)`
   height: 100%;
   background: #0065cc;
+  cursor: none;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/themes/Win10Update/Win10UpdateView.js
+++ b/src/themes/Win10Update/Win10UpdateView.js
@@ -25,6 +25,7 @@ export default styled(Win10UpdateView)`
   height: 100%;
   background: #0065cc;
   display: flex;
+  cursor: none;
   align-items: center;
   justify-content: center;
   font-family: 'Segoe UI light', Arial;


### PR DESCRIPTION
I have added `cursor: none;` in your stylesheet (MacOs Update / Win10 Update / Win10 BlueScreen / DVD ScreenSaver ).
I think it's more realistic to hide the cursor in pages like this.
Thanks 👍 